### PR TITLE
ft: Add gRPC services and handlers

### DIFF
--- a/app/grpc/base_handler.rb
+++ b/app/grpc/base_handler.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class BaseHandler
+  def self.inherited(subclass)
+    super
+    subclass.extend Grpc::Dsl
+  end
+
+  def initialize(request, meta)
+    @request = request
+    @meta = meta
+  end
+
+  attr_reader :request, :meta
+
+  def call
+    raise NotImplementedError, 'This class does not implement a service'
+  end
+end

--- a/app/grpc/delete_file_handler.rb
+++ b/app/grpc/delete_file_handler.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DeleteFileHandler < BaseHandler
+  def call
+    if uploaded_file.blank?
+      return Files::DeleteFileResponse.new(
+        success: false,
+        error_message: 'File not found'
+      )
+    end
+
+    uploaded_file.destroy!
+
+    Files::DeleteFileResponse.new(
+      success: true
+    )
+  end
+
+  private
+
+  def uploaded_file
+    @uploaded_file ||= UploadedFile.find_by(id: request.id)
+  end
+end

--- a/app/grpc/get_file_handler.rb
+++ b/app/grpc/get_file_handler.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class GetFileHandler < BaseHandler
+  def call
+    if file.blank?
+      return Files::GetFileResponse.new(
+        success: false,
+        error_message: 'File not found'
+      )
+    end
+
+    url = GenerateUrlService.call(
+      file,
+      {
+        download: request.download_url,
+        remote: request.remote_url,
+      }).data
+
+    Files::GetFileResponse.new(**
+                               { success: true,
+                                 name: file.filename.to_s,
+                                 type: file.content_type,
+                               }.merge(url)
+    )
+  end
+
+  private
+
+  def file
+    @file ||= UploadedFile.find_by(id: request.id)&.file
+  end
+end

--- a/app/grpc/upload_file_client_stream_handler.rb
+++ b/app/grpc/upload_file_client_stream_handler.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class UploadFileClientStreamHandler < BaseHandler
+  IMAGE_EXTENSIONS = %w[.jpg .jpeg .png .gif].freeze
+
+  def initialize(call)
+    # rubocop:disable Lint/MissingSuper
+    @call = call
+  end
+
+  def call
+    Rails.logger.info "Uploading file: #{filename}"
+
+    read_chunk
+
+    service = CreateFileService.call(temp_file, filename, mime_type)
+
+    raise service.first_error if service.error?
+
+    data = service.data
+    url = GenerateUrlService.call(
+      data.file,
+      {
+        download: true
+      }
+    ).data
+
+    Files::UploadFileResponse.new(**
+                                  {
+                                    id: data.id,
+                                    name: filename,
+                                    type: mime_type
+                                  }.merge(url)
+    )
+  ensure
+    # https://ruby-doc.org/stdlib-3.1.1/libdoc/tempfile/rdoc/Tempfile.html#class-Tempfile-label-Explicit+close
+    temp_file.close
+    temp_file.unlink
+  end
+
+  def temp_file
+    @temp_file ||= Tempfile.new(binmode: true)
+  end
+
+  def read_chunk
+    @call.each_remote_read do |upload_request|
+      Rails.logger.info "Received chunk of size: #{upload_request.content.bytesize}"
+      temp_file.write(upload_request.content)
+    end
+  end
+
+  def mime_type
+    @mime_type ||= Marcel::MimeType.for(temp_file, name: filename)
+  end
+
+  def metadata
+    @call.metadata
+  end
+
+  def filename
+    metadata['filename']
+  end
+end

--- a/app/services/base.rb
+++ b/app/services/base.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class BaseError < StandardError; end
+
+class FileNotFoundError < BaseError; end
+
+class Base
+  def self.call(*args, **kwargs)
+    service = new(*args, **kwargs)
+    service.call
+    service
+  end
+
+  def initialize(*_args, **_kwargs)
+    @errors = []
+  end
+
+  attr_reader :errors, :data
+
+  def success?
+    errors.empty?
+  end
+
+  def error?
+    errors.any?
+  end
+
+  def first_error
+    errors.first
+  end
+
+  def add_error(error)
+    @errors ||= []
+
+    return if error.nil?
+
+    if error.is_a?(BaseError)
+      error.set_backtrace(caller) if error.backtrace.nil?
+      errors << error
+    elsif error.is_a?(Array)
+      error.each { |e| add_error(e) }
+    else
+      err = BaseError.new(error)
+      err.set_backtrace(caller)
+      errors << err
+    end
+  end
+end

--- a/app/services/create_file_service.rb
+++ b/app/services/create_file_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateFileService < Base
+  def initialize(temp_file, filename, mime_type)
+    super
+
+    @temp_file = temp_file
+    @filename = filename
+    @mime_type = mime_type
+  end
+
+  def call
+    uploaded_file = UploadedFile.create!
+    uploaded_file.file.attach(
+      io: temp_file,
+      filename: filename,
+      content_type: mime_type
+    )
+
+    @data = uploaded_file
+
+    self
+  end
+
+  private
+
+  attr_reader :temp_file, :filename, :mime_type
+end

--- a/app/services/generate_url_service.rb
+++ b/app/services/generate_url_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class GenerateUrlService < Base
+  def initialize(file, option)
+    super
+
+    @file = file
+    @option = option
+  end
+
+  def call
+    @data = {}
+
+    build_data(:remote_url, remote_kwargs) if remote?
+    build_data(:download_url, download_kwargs) if download?
+
+    self
+  end
+
+  private
+
+  def download?
+    @option[:download] == true
+  end
+
+  def remote?
+    @option[:remote] == true
+  end
+
+  def remote_kwargs
+    @remote_kwargs ||= { only_path: true }
+  end
+
+  def download_kwargs
+    @download_kwargs ||= remote_kwargs.merge(disposition: "attachment")
+  end
+
+  def build_data(key, kwargs)
+    @data[key] ||= Rails.application.routes.url_helpers.rails_blob_path(@file, **kwargs)
+  end
+end


### PR DESCRIPTION
# Summary
Implement gRPC services and handlers 

# Changes proposed
- Add Base service and services 
- Implement Base handler, with auto extending `Grpc::Dsl` when subclasses inherit. Handlers are built on Base handler